### PR TITLE
Fixed bug where order created when exiting stripe

### DIFF
--- a/assets/scripts/order/events.js
+++ b/assets/scripts/order/events.js
@@ -41,6 +41,7 @@ const stripeHandler = StripeCheckout.configure({
       $('#message').text('Order placed successfully!')
       onCreateOrder()
       userEvents.emptyUserCart()
+      tokenTriggered = false
     }
   }
 })


### PR DESCRIPTION
If the user had placed a successful order, added items to their cart,
went to checkout again, and then exited the Stripe modal window, an
order was being created. This fix does not create a new order when the
user exits the Stripe modal without completing order.