### PR TITLE
Fix sign-up error handling, require password field

### DIFF
--- a/assets/scripts/users/events.js
+++ b/assets/scripts/users/events.js
@@ -26,7 +26,6 @@ const onRemoveProduct = (event) => {
   const product = {id: id}
   const data = {product}
   const row = button.parentElement.parentElement
-  // console.log(row)
   api.removeFromCart(data)
     .then(ui.removeProductSuccess)
     .then(() => {
@@ -74,6 +73,10 @@ const clearLoginMessage = () => {
   $('#login-message').text('')
 }
 
+const clearSignUpMessage = () => {
+  $('#signup-message').text('')
+}
+
 const addHandlers = () => {
   $('.content').on('click', '#add-to-cart', onAddToCart)
   $('.cart-content').on('click', '.removeProduct', onRemoveProduct)
@@ -84,6 +87,7 @@ const addHandlers = () => {
   $('#signupModal').on('hidden.bs.modal', clearSignUpForm)
   $('#passwordModal').on('hidden.bs.modal', clearPassForm)
   $('#passwordModal').on('show.bs.modal', clearPassMessage)
+  $('#signupModal').on('show.bs.modal', clearSignUpMessage)
 }
 
 module.exports = {

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
             <form class="form-horizontal" id="sign-up">
               <!-- <div class="form-group"> -->
                 <input type="email" name="credentials[email]" id="sign-up-email" class="form-control" placeholder="Email">
-                <input type="password" name="credentials[password]" id="sign-up-password" class="form-control" placeholder="Password">
+                <input type="password" name="credentials[password]" id="sign-up-password" class="form-control" placeholder="Password" required>
                 <input type="password" name="credentials[password_confirmation]" id="sign-up-password-confirmation" class="form-control" placeholder="Confirm Password">
                  <div class="modal-body">
                    <br>
@@ -96,8 +96,8 @@
                 <span id="password-message"></span>
                </div>
             <form class="form-horizontal" id="change-password">
-            <input type="password" name="passwords[old]" id="change-password-old" class="form-control" placeholder="Current Passward">
-            <input type="password" name="passwords[new]" id="change-password-new" class="form-control" placeholder="New Password">
+            <input type="password" name="passwords[old]" id="change-password-old" class="form-control" placeholder="Current Passward" required>
+            <input type="password" name="passwords[new]" id="change-password-new" class="form-control" placeholder="New Password" required>
              <div class="modal-body">
                <br>
              </div>


### PR DESCRIPTION
- Clear sign-up form when loaded so that error message does not persist
- Require password fields in `change password` & `sign-up`

Mike, Cole, Mark, Rina